### PR TITLE
Fix jpn wording

### DIFF
--- a/src/languages/jpn.json
+++ b/src/languages/jpn.json
@@ -1,5 +1,5 @@
 {
-    "old_version": "新しい",
-    "new_version": "古い",
+    "old_version": "古い",
+    "new_version": "新しい",
     "differences": "差異"
 }


### PR DESCRIPTION
Thanks for this wonderful library!
Japanese translation of 'old_version' and 'new_version' seems upside down.