### PR TITLE
Ability to render HTML from JSON

### DIFF
--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -141,6 +141,14 @@ abstract class AbstractRenderer implements RendererInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    final public function renderArray(array $differArray): string
+    {
+        return $this->renderArrayWoker($differArray);
+    }
+
+    /**
      * The real worker for self::render().
      *
      * @param Differ $differ the differ object
@@ -154,7 +162,7 @@ abstract class AbstractRenderer implements RendererInterface
      *
      * @return string
      */
-    abstract protected function arrayRenderWoker(array $differArray): string;
+    abstract protected function renderArrayWoker(array $differArray): string;
 	
 	/**
      * Woker's base function.

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -146,6 +146,24 @@ abstract class AbstractRenderer implements RendererInterface
      * @param Differ $differ the differ object
      */
     abstract protected function renderWoker(Differ $differ): string;
+    
+    /**
+     * The worker for array render.
+     *
+     * @param array $differArray the differ array
+     *
+     * @return string
+     */
+    abstract protected function arrayRenderWoker(array $differArray): string;
+	
+	/**
+     * Woker's base function.
+     *
+     * @param array $changes the changes array
+     *
+     * @return string
+     */
+    abstract protected function baseWoker(array $changes): string;
 
     /**
      * Update the Language object.

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -163,8 +163,8 @@ abstract class AbstractRenderer implements RendererInterface
      * @return string
      */
     abstract protected function renderArrayWoker(array $differArray): string;
-	
-	/**
+    
+    /**
      * Woker's base function.
      *
      * @param array $changes the changes array

--- a/src/Renderer/Html/Inline.php
+++ b/src/Renderer/Html/Inline.php
@@ -33,7 +33,7 @@ final class Inline extends AbstractHtml
 	/**
      * {@inheritdoc}
      */
-    protected function arrayRenderWoker(array $differArray): string
+    protected function renderArrayWoker(array $differArray): string
     {
 		$changes = $differArray;
 

--- a/src/Renderer/Html/Inline.php
+++ b/src/Renderer/Html/Inline.php
@@ -26,11 +26,29 @@ final class Inline extends AbstractHtml
     protected function renderWoker(Differ $differ): string
     {
         $changes = $this->getChanges($differ);
+		
+		return $this->baseWoker($changes);
+    }
+	
+	/**
+     * {@inheritdoc}
+     */
+    protected function arrayRenderWoker(array $differArray): string
+    {
+		$changes = $differArray;
 
-        if (empty($changes)) {
+        return $this->baseWoker($changes);
+    }
+	
+	/**
+     * {@inheritdoc}
+     */
+    protected function baseWoker(array $changes): string
+    {
+		if (empty($changes)) {
             return $this->getResultForIdenticals();
         }
-
+		
         $wrapperClasses = \array_merge(
             $this->options['wrapperClasses'],
             ['diff', 'diff-html', 'diff-inline']
@@ -51,7 +69,7 @@ final class Inline extends AbstractHtml
         }
 
         return $html . '</table>';
-    }
+	}
 
     /**
      * Renderer the table header.

--- a/src/Renderer/Html/Inline.php
+++ b/src/Renderer/Html/Inline.php
@@ -26,29 +26,29 @@ final class Inline extends AbstractHtml
     protected function renderWoker(Differ $differ): string
     {
         $changes = $this->getChanges($differ);
-		
-		return $this->baseWoker($changes);
+        
+        return $this->baseWoker($changes);
     }
-	
-	/**
+    
+    /**
      * {@inheritdoc}
      */
     protected function renderArrayWoker(array $differArray): string
     {
-		$changes = $differArray;
+        $changes = $differArray;
 
         return $this->baseWoker($changes);
     }
-	
-	/**
+    
+    /**
      * {@inheritdoc}
      */
     protected function baseWoker(array $changes): string
     {
-		if (empty($changes)) {
+        if (empty($changes)) {
             return $this->getResultForIdenticals();
         }
-		
+        
         $wrapperClasses = \array_merge(
             $this->options['wrapperClasses'],
             ['diff', 'diff-html', 'diff-inline']
@@ -69,7 +69,7 @@ final class Inline extends AbstractHtml
         }
 
         return $html . '</table>';
-	}
+    }
 
     /**
      * Renderer the table header.

--- a/src/Renderer/Html/Json.php
+++ b/src/Renderer/Html/Json.php
@@ -51,6 +51,22 @@ final class Json extends AbstractHtml
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function arrayRenderWoker(): string
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function baseWoker(): string
+    {
+        return '';
+    }
+
+    /**
      * Convert tags of changes to their string form for better readability.
      *
      * @param array $changes the changes

--- a/src/Renderer/Html/Json.php
+++ b/src/Renderer/Html/Json.php
@@ -53,7 +53,7 @@ final class Json extends AbstractHtml
     /**
      * {@inheritdoc}
      */
-    public function arrayRenderWoker(): string
+    public function arrayRenderWoker(array $differArray): string
     {
         return '';
     }
@@ -61,7 +61,7 @@ final class Json extends AbstractHtml
     /**
      * {@inheritdoc}
      */
-    public function baseWoker(): string
+    public function baseWoker(array $changes): string
     {
         return '';
     }

--- a/src/Renderer/Html/Json.php
+++ b/src/Renderer/Html/Json.php
@@ -53,7 +53,7 @@ final class Json extends AbstractHtml
     /**
      * {@inheritdoc}
      */
-    public function arrayRenderWoker(array $differArray): string
+    public function renderArrayWoker(array $differArray): string
     {
         return '';
     }

--- a/src/Renderer/Html/SideBySide.php
+++ b/src/Renderer/Html/SideBySide.php
@@ -33,7 +33,7 @@ final class SideBySide extends AbstractHtml
 	/**
      * {@inheritdoc}
      */
-    protected function arrayRenderWoker(array $differArray): string
+    protected function renderArrayWoker(array $differArray): string
     {
         $changes = $differArray;
 

--- a/src/Renderer/Html/SideBySide.php
+++ b/src/Renderer/Html/SideBySide.php
@@ -27,7 +27,7 @@ final class SideBySide extends AbstractHtml
     {
         $changes = $this->getChanges($differ);
 		
-		return $this->baseWoker($changes);
+        return $this->baseWoker($changes);
     }
 	
 	/**
@@ -36,8 +36,8 @@ final class SideBySide extends AbstractHtml
     protected function renderArrayWoker(array $differArray): string
     {
         $changes = $differArray;
-		
-		return $this->baseWoker($changes);
+        
+        return $this->baseWoker($changes);
     }
 	
 	/**

--- a/src/Renderer/Html/SideBySide.php
+++ b/src/Renderer/Html/SideBySide.php
@@ -26,11 +26,11 @@ final class SideBySide extends AbstractHtml
     protected function renderWoker(Differ $differ): string
     {
         $changes = $this->getChanges($differ);
-		
+        
         return $this->baseWoker($changes);
     }
-	
-	/**
+    
+    /**
      * {@inheritdoc}
      */
     protected function renderArrayWoker(array $differArray): string
@@ -39,13 +39,13 @@ final class SideBySide extends AbstractHtml
         
         return $this->baseWoker($changes);
     }
-	
-	/**
+    
+    /**
      * {@inheritdoc}
      */
     protected function baseWoker(array $changes): string
     {
-		if (empty($changes)) {
+        if (empty($changes)) {
             return $this->getResultForIdenticals();
         }
 
@@ -69,7 +69,7 @@ final class SideBySide extends AbstractHtml
         }
 
         return $html . '</table>';
-	}
+    }
 
     /**
      * Renderer the table header.

--- a/src/Renderer/Html/SideBySide.php
+++ b/src/Renderer/Html/SideBySide.php
@@ -26,8 +26,26 @@ final class SideBySide extends AbstractHtml
     protected function renderWoker(Differ $differ): string
     {
         $changes = $this->getChanges($differ);
+		
+		return $this->baseWoker($changes);
+    }
+	
+	/**
+     * {@inheritdoc}
+     */
+    protected function arrayRenderWoker(array $differArray): string
+    {
+        $changes = $differArray;
 
-        if (empty($changes)) {
+        return $this->baseWoker($changes);
+    }
+	
+	/**
+     * {@inheritdoc}
+     */
+    protected function baseWoker(array $changes): string
+    {
+		if (empty($changes)) {
             return $this->getResultForIdenticals();
         }
 
@@ -51,7 +69,7 @@ final class SideBySide extends AbstractHtml
         }
 
         return $html . '</table>';
-    }
+	}
 
     /**
      * Renderer the table header.

--- a/src/Renderer/Html/SideBySide.php
+++ b/src/Renderer/Html/SideBySide.php
@@ -36,8 +36,8 @@ final class SideBySide extends AbstractHtml
     protected function renderArrayWoker(array $differArray): string
     {
         $changes = $differArray;
-
-        return $this->baseWoker($changes);
+		
+		return $this->baseWoker($changes);
     }
 	
 	/**

--- a/src/Renderer/RendererInterface.php
+++ b/src/Renderer/RendererInterface.php
@@ -22,4 +22,13 @@ interface RendererInterface
      * @param Differ $differ the Differ object to be rendered
      */
     public function render(Differ $differ): string;
+    
+    /**
+     * Render the differ array and return the result.
+     *
+     * @param array $differArray the Differ array to be rendered
+     *
+     * @return string
+     */
+    public function renderArray(array $differArray): string;
 }

--- a/src/Renderer/Text/AbstractText.php
+++ b/src/Renderer/Text/AbstractText.php
@@ -23,4 +23,20 @@ abstract class AbstractText extends AbstractRenderer
     {
         return '';
     }
+	
+	/**
+     * {@inheritdoc}
+     */
+    public function arrayRenderWoker(): string
+    {
+        return '';
+    }
+	
+	/**
+     * {@inheritdoc}
+     */
+    public function baseWoker(): string
+    {
+        return '';
+    }
 }

--- a/src/Renderer/Text/AbstractText.php
+++ b/src/Renderer/Text/AbstractText.php
@@ -23,16 +23,16 @@ abstract class AbstractText extends AbstractRenderer
     {
         return '';
     }
-	
-	/**
+    
+    /**
      * {@inheritdoc}
      */
     public function renderArrayWoker(array $differArray): string
     {
         return '';
     }
-	
-	/**
+    
+    /**
      * {@inheritdoc}
      */
     public function baseWoker(array $changes): string

--- a/src/Renderer/Text/AbstractText.php
+++ b/src/Renderer/Text/AbstractText.php
@@ -27,7 +27,7 @@ abstract class AbstractText extends AbstractRenderer
 	/**
      * {@inheritdoc}
      */
-    public function arrayRenderWoker(array $differArray): string
+    public function renderArrayWoker(array $differArray): string
     {
         return '';
     }

--- a/src/Renderer/Text/AbstractText.php
+++ b/src/Renderer/Text/AbstractText.php
@@ -27,7 +27,7 @@ abstract class AbstractText extends AbstractRenderer
 	/**
      * {@inheritdoc}
      */
-    public function arrayRenderWoker(): string
+    public function arrayRenderWoker(array $differArray): string
     {
         return '';
     }
@@ -35,7 +35,7 @@ abstract class AbstractText extends AbstractRenderer
 	/**
      * {@inheritdoc}
      */
-    public function baseWoker(): string
+    public function baseWoker(array $changes): string
     {
         return '';
     }


### PR DESCRIPTION
For [#16](https://github.com/jfcherng/php-diff/issues/16) 

okay i've made some radical changes so take your time to analyze it.

with these changes, you'll be able to convert JSON renderer's output to any other HTML (Inline or SideBySide) renderer's output.

Here's a sample usage:

```
$old = "old text";
$new = "new text";
$differOptions = [ ... ];
$rendererOptions = [ ... ];

// JSON result to store in a db table
$JsonResult = DiffHelper::calculate($old, $new, 'Json', $differOptions, $rendererOptions);
----------------
// Convert it to HTML (Inline Style)
$renderer = RendererFactory::make('Inline', $rendererOptions);
$InlineResult = $renderer->renderArray(json_decode($JsonResult, true));
```