### PR TITLE
fix: "wordGlues" works wrongly under some circumstances

### DIFF
--- a/src/Renderer/Html/AbstractHtml.php
+++ b/src/Renderer/Html/AbstractHtml.php
@@ -119,7 +119,9 @@ abstract class AbstractHtml extends AbstractRenderer
      */
     protected function renderWorker(Differ $differ): string
     {
-        return $this->redererChanges($this->getChanges($differ));
+        $rendered = $this->redererChanges($this->getChanges($differ));
+
+        return $this->cleanUpDummyHtmlClosures($rendered);
     }
 
     /**
@@ -129,7 +131,9 @@ abstract class AbstractHtml extends AbstractRenderer
     {
         $this->ensureChangesUseIntTag($differArray);
 
-        return $this->redererChanges($differArray);
+        $rendered = $this->redererChanges($differArray);
+
+        return $this->cleanUpDummyHtmlClosures($rendered);
     }
 
     /**
@@ -316,5 +320,22 @@ abstract class AbstractHtml extends AbstractRenderer
                 $block['tag'] = SequenceMatcher::opStrToInt($block['tag']);
             }
         }
+    }
+
+    /**
+     * Clean up empty HTML closures in the given string.
+     *
+     * @param string $string the string
+     */
+    protected function cleanUpDummyHtmlClosures(string $string): string
+    {
+        return \str_replace(
+            [
+                RendererConstant::HTML_CLOSURES_DEL[0] . RendererConstant::HTML_CLOSURES_DEL[1],
+                RendererConstant::HTML_CLOSURES_INS[0] . RendererConstant::HTML_CLOSURES_INS[1],
+            ],
+            '',
+            $string
+        );
     }
 }


### PR DESCRIPTION
## Bug Description

If we have a diffed circumstance like the following,
```
old: ... a-<del>B</del>-<del>C</del> ...
new: ... a-<ins>b</ins>- ...
```
we want to glue them into
```
old: ... a-<del>B-C</del> ...
new: ... a-<ins>b-</ins> ...
```
But instead, because of this bug, we have incorrect
```
old: ... a-<del>B-C</del> ...
new: ... a-<ins>b</ins>- ...
```


## Fix

We can fix this by adding some dummy closures before glueing like
```
old: ... a-<del>B</del>-<del>C</del> ...
new: ... a-<ins>b</ins>-<ins></ins> ...
                        ^^^^^^^^^^^ dummy closure
```
so that now "old" and "new" have the same amounts of closures.


## Reproducer

Use `word-level` and `Combined` renderer to test.

- [old.txt](https://github.com/jfcherng/php-diff/files/4399268/old.txt)
- [new.txt](https://github.com/jfcherng/php-diff/files/4399267/new.txt)
