### PR TITLE
feat: support console color for Unified and Context renderers

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -18,6 +18,7 @@ return [
         'src',
         'vendor/jfcherng/php-mb-string/src',
         'vendor/jfcherng/php-sequence-matcher/src',
+        'vendor/symfony/console',
     ],
 
     // A directory list that defines files that will be excluded

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ include __DIR__ . '/vendor/autoload.php';
 use Jfcherng\Diff\Differ;
 use Jfcherng\Diff\DiffHelper;
 use Jfcherng\Diff\Factory\RendererFactory;
+use Jfcherng\Diff\Renderer\RendererConstant;
 
 $oldFile = __DIR__ . '/example/old_file.txt';
 $newFile = __DIR__ . '/example/new_file.txt';
@@ -104,6 +105,11 @@ $rendererOptions = [
     // it determines whether a replace-type block should be merged or not
     // depending on the content changed ratio, which values between 0 and 1.
     'mergeThreshold' => 0.8,
+    // this option is currently only for the Unified and the Context renderers.
+    // RendererConstant::CLI_COLOR_AUTO = colorize the output if possible (default)
+    // RendererConstant::CLI_COLOR_ENABLE = force to colorize the output
+    // RendererConstant::CLI_COLOR_DISABLE = force not to colorize the output
+    'cliColorization' => RendererConstant::CLI_COLOR_AUTO,
     // this option is currently only for the Json renderer.
     // internally, ops (tags) are all int type but this is not good for human reading.
     // set this to "true" to convert them into string form before outputting.

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "require": {
         "php": "^7.1.3",
         "jfcherng/php-mb-string": "^1.3",
-        "jfcherng/php-sequence-matcher": "^3.2.2"
+        "jfcherng/php-sequence-matcher": "^3.2.2",
+        "symfony/console": ">=3 <6"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5053830acb49d256a5da7002c0ddba82",
+    "content-hash": "3483f2898e1bbf01976280c0a5c2cb4c",
     "packages": [
         {
             "name": "jfcherng/php-mb-string",
@@ -98,6 +98,145 @@
             "time": "2020-03-06T12:50:28+00:00"
         },
         {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
+                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-30T11:42:42+00:00"
+        },
+        {
             "name": "symfony/polyfill-iconv",
             "version": "v1.15.0",
             "source": {
@@ -169,6 +308,209 @@
                 }
             ],
             "time": "2020-03-09T19:04:49+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-09T19:04:49+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7",
+                "reference": "0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-18T17:27:11+00:00"
         }
     ],
     "packages-dev": [
@@ -1621,55 +1963,6 @@
             "time": "2020-03-31T08:57:51+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "time": "2017-02-14T16:28:37+00:00"
-        },
-        {
             "name": "psr/event-dispatcher",
             "version": "1.0.0",
             "source": {
@@ -2498,58 +2791,38 @@
             "time": "2020-01-30T22:20:29+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v5.0.7",
+            "name": "symfony/debug",
+            "version": "v4.4.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935"
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "346636d2cae417992ecfd761979b2ab98b339a45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
-                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/346636d2cae417992ecfd761979b2ab98b339a45",
+                "reference": "346636d2cae417992ecfd761979b2ab98b339a45",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.8",
-                "symfony/service-contracts": "^1.1|^2"
+                "php": "^7.1.3",
+                "psr/log": "~1.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<4.4",
-                "symfony/event-dispatcher": "<4.4",
-                "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0"
+                "symfony/http-kernel": "<3.4"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^4.4|^5.0",
-                "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
+                    "Symfony\\Component\\Debug\\": ""
                 },
                 "exclude-from-classmap": [
                     "/Tests/"
@@ -2569,7 +2842,7 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Console Component",
+            "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
             "funding": [
                 {
@@ -2585,7 +2858,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-03-30T11:42:42+00:00"
+            "time": "2020-03-27T16:54:36+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2997,79 +3270,6 @@
             "time": "2020-02-27T09:26:54+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
-                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.15-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-03-09T19:04:49+00:00"
-        },
-        {
             "name": "symfony/polyfill-php70",
             "version": "v1.15.0",
             "source": {
@@ -3198,78 +3398,6 @@
             "time": "2020-02-27T09:26:54+00:00"
         },
         {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7",
-                "reference": "0f27e9f464ea3da33cbe7ca3bdf4eb66def9d0f7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.15-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-02-27T09:26:54+00:00"
-        },
-        {
             "name": "symfony/process",
             "version": "v5.0.7",
             "source": {
@@ -3331,64 +3459,6 @@
                 }
             ],
             "time": "2020-03-27T16:56:45+00:00"
-        },
-        {
-            "name": "symfony/service-contracts",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "144c5e51266b281231e947b51223ba14acf1a749"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
-                "reference": "144c5e51266b281231e947b51223ba14acf1a749",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5",
-                "psr/container": "^1.0"
-            },
-            "suggest": {
-                "symfony/service-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2019-11-18T17:27:11+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/example/demo.php
+++ b/example/demo.php
@@ -1,8 +1,7 @@
 <?php
 
-include __DIR__ . '/../vendor/autoload.php';
+include __DIR__ . '/demo_base.php';
 
-use Jfcherng\Diff\Differ;
 use Jfcherng\Diff\DiffHelper;
 use Jfcherng\Diff\Factory\RendererFactory;
 
@@ -33,66 +32,6 @@ use Jfcherng\Diff\Factory\RendererFactory;
         </style>
     </head>
     <body>
-        <?php
-
-        // the two sample files for comparison
-        $oldFile = __DIR__ . '/old_file.txt';
-        $newFile = __DIR__ . '/new_file.txt';
-        $oldString = \file_get_contents($oldFile);
-        $newString = \file_get_contents($newFile);
-
-        // options for Diff class
-        $diffOptions = [
-            // show how many neighbor lines
-            // Differ::CONTEXT_ALL can be used to show the whole file
-            'context' => 1,
-            // ignore case difference
-            'ignoreCase' => false,
-            // ignore whitespace difference
-            'ignoreWhitespace' => false,
-        ];
-
-        // options for renderer class
-        $rendererOptions = [
-            // how detailed the rendered HTML is? (none, line, word, char)
-            'detailLevel' => 'line',
-            // renderer language: eng, cht, chs, jpn, ...
-            // or an array which has the same keys with a language file
-            'language' => 'eng',
-            // show line numbers in HTML renderers
-            'lineNumbers' => true,
-            // show a separator between different diff hunks in HTML renderers
-            'separateBlock' => true,
-            // the frontend HTML could use CSS "white-space: pre;" to visualize consecutive whitespaces
-            // but if you want to visualize them in the backend with "&nbsp;", you can set this to true
-            'spacesToNbsp' => false,
-            // HTML renderer tab width (negative = do not convert into spaces)
-            'tabSize' => 4,
-            // this option is currently only for the Combined renderer.
-            // it determines whether a replace-type block should be merged or not
-            // depending on the content changed ratio, which values between 0 and 1.
-            'mergeThreshold' => 0.8,
-            // this option is currently only for the Json renderer.
-            // internally, ops (tags) are all int type but this is not good for human reading.
-            // set this to "true" to convert them into string form before outputting.
-            'outputTagAsString' => false,
-            // this option is currently only for the Json renderer.
-            // it controls how the output JSON is formatted.
-            // see availabe options on https://www.php.net/manual/en/function.json-encode.php
-            'jsonEncodeFlags' => \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
-            // this option is currently effective when the "detailLevel" is "word"
-            // characters listed in this array can be used to make diff segments into a whole
-            // for example, making "<del>good</del>-<del>looking</del>" into "<del>good-looking</del>"
-            // this should bring better readability but set this to empty array if you do not want it
-            'wordGlues' => [' ', '-'],
-            // change this value to a string as the returned diff if the two input strings are identical
-            'resultForIdenticals' => null,
-            // extra HTML classes added to the DOM of the diff container
-            'wrapperClasses' => ['diff-wrapper'],
-        ];
-
-        ?>
-
         <h1>None-level Diff</h1>
         <?php
 

--- a/example/demo_base.php
+++ b/example/demo_base.php
@@ -1,0 +1,67 @@
+<?php
+
+include __DIR__ . '/../vendor/autoload.php';
+
+use Jfcherng\Diff\Differ;
+use Jfcherng\Diff\Renderer\RendererConstant;
+
+// the two sample files for comparison
+$oldFile = __DIR__ . '/old_file.txt';
+$newFile = __DIR__ . '/new_file.txt';
+$oldString = \file_get_contents($oldFile);
+$newString = \file_get_contents($newFile);
+
+// options for Diff class
+$diffOptions = [
+    // show how many neighbor lines
+    // Differ::CONTEXT_ALL can be used to show the whole file
+    'context' => 1,
+    // ignore case difference
+    'ignoreCase' => false,
+    // ignore whitespace difference
+    'ignoreWhitespace' => false,
+];
+
+// options for renderer class
+$rendererOptions = [
+    // how detailed the rendered HTML is? (none, line, word, char)
+    'detailLevel' => 'line',
+    // renderer language: eng, cht, chs, jpn, ...
+    // or an array which has the same keys with a language file
+    'language' => 'eng',
+    // show line numbers in HTML renderers
+    'lineNumbers' => true,
+    // show a separator between different diff hunks in HTML renderers
+    'separateBlock' => true,
+    // the frontend HTML could use CSS "white-space: pre;" to visualize consecutive whitespaces
+    // but if you want to visualize them in the backend with "&nbsp;", you can set this to true
+    'spacesToNbsp' => false,
+    // HTML renderer tab width (negative = do not convert into spaces)
+    'tabSize' => 4,
+    // this option is currently only for the Combined renderer.
+    // it determines whether a replace-type block should be merged or not
+    // depending on the content changed ratio, which values between 0 and 1.
+    'mergeThreshold' => 0.8,
+    // this option is currently only for the Unified and the Context renderers.
+    // RendererConstant::CLI_COLOR_AUTO = colorize the output if possible (default)
+    // RendererConstant::CLI_COLOR_ENABLE = force to colorize the output
+    // RendererConstant::CLI_COLOR_DISABLE = force not to colorize the output
+    'cliColorization' => RendererConstant::CLI_COLOR_AUTO,
+    // this option is currently only for the Json renderer.
+    // internally, ops (tags) are all int type but this is not good for human reading.
+    // set this to "true" to convert them into string form before outputting.
+    'outputTagAsString' => false,
+    // this option is currently only for the Json renderer.
+    // it controls how the output JSON is formatted.
+    // see availabe options on https://www.php.net/manual/en/function.json-encode.php
+    'jsonEncodeFlags' => \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
+    // this option is currently effective when the "detailLevel" is "word"
+    // characters listed in this array can be used to make diff segments into a whole
+    // for example, making "<del>good</del>-<del>looking</del>" into "<del>good-looking</del>"
+    // this should bring better readability but set this to empty array if you do not want it
+    'wordGlues' => [' ', '-'],
+    // change this value to a string as the returned diff if the two input strings are identical
+    'resultForIdenticals' => null,
+    // extra HTML classes added to the DOM of the diff container
+    'wrapperClasses' => ['diff-wrapper'],
+];

--- a/example/demo_cli.php
+++ b/example/demo_cli.php
@@ -1,0 +1,46 @@
+<?php
+
+include __DIR__ . '/demo_base.php';
+
+use Jfcherng\Diff\DiffHelper;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Output\StreamOutput;
+
+$output = new StreamOutput(
+    \fopen('php://stdout', 'w'),
+    StreamOutput::VERBOSITY_NORMAL,
+    null,
+    new OutputFormatter(
+        false,
+        [
+            'section' => new OutputFormatterStyle('white', 'cyan', ['bold']),
+        ]
+    )
+);
+
+$output->writeln("<section>Unified Diff\n============\n</>");
+
+// generate a unified diff
+$unifiedResult = DiffHelper::calculate(
+    $oldString,
+    $newString,
+    'Unified',
+    $diffOptions,
+    $rendererOptions
+);
+
+echo $unifiedResult . "\n\n\n\n";
+
+$output->writeln("<section>Context Diff\n============\n</>");
+
+// generate a context diff
+$contextResult = DiffHelper::calculate(
+    $oldString,
+    $newString,
+    'Context',
+    $diffOptions,
+    $rendererOptions
+);
+
+echo $contextResult . "\n\n\n\n";

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -63,6 +63,11 @@ abstract class AbstractRenderer implements RendererInterface
         // it determines whether a replace-type block should be merged or not
         // depending on the content changed ratio, which values between 0 and 1.
         'mergeThreshold' => 0.8,
+        // this option is currently only for the Unified and the Context renderers.
+        // RendererConstant::CLI_COLOR_AUTO = colorize the output if possible (default)
+        // RendererConstant::CLI_COLOR_ENABLE = force to colorize the output
+        // RendererConstant::CLI_COLOR_DISABLE = force not to colorize the output
+        'cliColorization' => RendererConstant::CLI_COLOR_AUTO,
         // this option is currently only for the Json renderer.
         // internally, ops (tags) are all int type but this is not good for human reading.
         // set this to "true" to convert them into string form before outputting.

--- a/src/Renderer/RendererConstant.php
+++ b/src/Renderer/RendererConstant.php
@@ -92,4 +92,25 @@ final class RendererConstant
         '「」『』〈〉《》【】()（）‘’“”' .
         '．‧・･•·¿'
     );
+
+    /**
+     * Colorize the CLI output if possible.
+     *
+     * @var int
+     */
+    const CLI_COLOR_AUTO = -1;
+
+    /**
+     * Force not to colorize the CLI output.
+     *
+     * @var int
+     */
+    const CLI_COLOR_DISABLE = 0;
+
+    /**
+     * Force to colorize the CLI output if possible.
+     *
+     * @var int
+     */
+    const CLI_COLOR_ENABLE = 1;
 }

--- a/src/Renderer/Text/AbstractText.php
+++ b/src/Renderer/Text/AbstractText.php
@@ -166,6 +166,8 @@ abstract class AbstractText extends AbstractRenderer
      * @param resource $stream
      *
      * @return bool true if the stream supports colorization, false otherwise
+     *
+     * @suppress PhanUndeclaredFunction
      */
     protected function hasColorSupport($stream): bool
     {

--- a/src/Renderer/Text/AbstractText.php
+++ b/src/Renderer/Text/AbstractText.php
@@ -6,6 +6,11 @@ namespace Jfcherng\Diff\Renderer\Text;
 
 use Jfcherng\Diff\Exception\UnsupportedFunctionException;
 use Jfcherng\Diff\Renderer\AbstractRenderer;
+use Jfcherng\Diff\Renderer\RendererConstant;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Base renderer for rendering text-based diffs.
@@ -23,6 +28,39 @@ abstract class AbstractText extends AbstractRenderer
     const GNU_OUTPUT_NO_EOL_AT_EOF = '\ No newline at end of file';
 
     /**
+     * @var BufferedOutput
+     */
+    protected $bufferOutput;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $options = [])
+    {
+        $this->bufferOutput = $this->getCliOutputter();
+
+        parent::__construct($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options): AbstractRenderer
+    {
+        parent::setOptions($options);
+
+        if ($this->options['cliColorization'] === RendererConstant::CLI_COLOR_ENABLE) {
+            $this->bufferOutput->setDecorated(true);
+        } elseif ($this->options['cliColorization'] === RendererConstant::CLI_COLOR_DISABLE) {
+            $this->bufferOutput->setDecorated(false);
+        } else {
+            $this->bufferOutput->setDecorated($this->isCliColorSupported());
+        }
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getResultForIdenticalsDefault(): string
@@ -38,5 +76,126 @@ abstract class AbstractText extends AbstractRenderer
         throw new UnsupportedFunctionException(__METHOD__);
 
         return ''; // make IDE not complain
+    }
+
+    /**
+     * Get the cli outputter object.
+     */
+    protected function getCliOutputter(): OutputInterface
+    {
+        return new BufferedOutput(
+            OutputInterface::VERBOSITY_NORMAL,
+            false,
+            new OutputFormatter(
+                false,
+                [
+                    'header' => new OutputFormatterStyle('magenta', null, []),
+                    'deleted' => new OutputFormatterStyle('red', null, ['bold']),
+                    'inserted' => new OutputFormatterStyle('green', null, ['bold']),
+                    'replaced' => new OutputFormatterStyle('yellow', null, ['bold']),
+                ]
+            )
+        );
+    }
+
+    /**
+     * Colorize the string for CLI output.
+     *
+     * @param string      $str   the string
+     * @param null|string $style the style
+     *
+     * @return string the (maybe) colorized string
+     */
+    protected function cliColoredString(string $str, ?string $style = null): string
+    {
+        static $symbolStyleMap = [
+            '@' => 'header',
+            '-' => 'deleted',
+            '+' => 'inserted',
+            '!' => 'replaced',
+        ];
+
+        // just to reduce the amount of function calls
+        if (!$this->bufferOutput->isDecorated()) {
+            return $str;
+        }
+
+        // convert symbol into style
+        if (\is_string($style) && isset($style[0]) && !\ctype_alpha($style[0])) {
+            $style = $symbolStyleMap[$style] ?? null;
+        }
+
+        $str = OutputFormatter::escape($str);
+
+        $this->bufferOutput->write(isset($style) ? "<{$style}>{$str}</>" : $str);
+
+        return $this->bufferOutput->fetch();
+    }
+
+    /**
+     * Determine if cli color supported.
+     */
+    protected function isCliColorSupported(): bool
+    {
+        static $isSupported;
+
+        if (isset($isSupported)) {
+            return $isSupported;
+        }
+
+        $stream = \fopen('php://stdout', 'w');
+        $isSupported = \PHP_SAPI === 'cli' && $this->hasColorSupport($stream);
+        \fclose($stream);
+
+        return $isSupported;
+    }
+
+    /**
+     * Returns true if the stream supports colorization.
+     *
+     * Colorization is disabled if not supported by the stream:
+     *
+     * This is tricky on Windows, because Cygwin, Msys2 etc emulate pseudo
+     * terminals via named pipes, so we can only check the environment.
+     *
+     * Reference: Composer\XdebugHandler\Process::supportsColor
+     * https://github.com/composer/xdebug-handler
+     *
+     * @see https://github.com/symfony/console/blob/4.4/Output/StreamOutput.php#L94
+     *
+     * @param resource $stream
+     *
+     * @return bool true if the stream supports colorization, false otherwise
+     */
+    protected function hasColorSupport($stream): bool
+    {
+        // Follow https://no-color.org/
+        if (isset($_SERVER['NO_COLOR']) || false !== \getenv('NO_COLOR')) {
+            return false;
+        }
+
+        if ('Hyper' === \getenv('TERM_PROGRAM')) {
+            return true;
+        }
+
+        if (\DIRECTORY_SEPARATOR === '\\') {
+            return (\function_exists('sapi_windows_vt100_support')
+                && @\sapi_windows_vt100_support($stream))
+                || false !== \getenv('ANSICON')
+                || 'ON' === \getenv('ConEmuANSI')
+                || 'xterm' === \getenv('TERM');
+        }
+
+        if (\function_exists('stream_isatty')) {
+            return @\stream_isatty($stream);
+        }
+
+        if (\function_exists('posix_isatty')) {
+            return @posix_isatty($stream);
+        }
+
+        $stat = @\fstat($stream);
+        // Check if formatted mode is S_IFCHR
+        return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
     }
 }

--- a/src/Renderer/Text/Context.php
+++ b/src/Renderer/Text/Context.php
@@ -47,7 +47,7 @@ final class Context extends AbstractText
             $j2 = $hunk[$lastBlockIdx][4];
 
             $ret .=
-                "***************\n" .
+                $this->cliColoredString("***************\n", '@') .
                 $this->renderHunkHeader('*', $i1, $i2) .
                 $this->renderHunkOld($differ, $hunk) .
                 $this->renderHunkHeader('-', $j1, $j2) .
@@ -68,10 +68,12 @@ final class Context extends AbstractText
     {
         $a1x = $a1 + 1; // 1-based begin line number
 
-        return
+        return $this->cliColoredString(
             "{$symbol}{$symbol}{$symbol} " .
             ($a1x < $a2 ? "{$a1x},{$a2}" : $a2) .
-            " {$symbol}{$symbol}{$symbol}{$symbol}\n";
+            " {$symbol}{$symbol}{$symbol}{$symbol}\n",
+            '@' // symbol
+        );
     }
 
     /**
@@ -150,6 +152,7 @@ final class Context extends AbstractText
         }
 
         $ret = "{$symbol} " . \implode("\n{$symbol} ", $context) . "\n";
+        $ret = $this->cliColoredString($ret, $symbol);
 
         if ($noEolAtEof) {
             $ret .= self::GNU_OUTPUT_NO_EOL_AT_EOF . "\n";

--- a/src/Renderer/Text/Unified.php
+++ b/src/Renderer/Text/Unified.php
@@ -56,7 +56,7 @@ final class Unified extends AbstractText
         $oldLinesCount = $i2 - $i1;
         $newLinesCount = $j2 - $j1;
 
-        return
+        return $this->cliColoredString(
             '@@' .
             ' -' .
                 // the line number in GNU diff is 1-based, so we add 1
@@ -68,7 +68,9 @@ final class Unified extends AbstractText
             ' +' .
                 ($j1 === $j2 ? $j1 : $j1 + 1) .
                 ($newLinesCount === 1 ? '' : ",{$newLinesCount}") .
-            " @@\n";
+            " @@\n",
+            '@' // symbol
+        );
     }
 
     /**
@@ -134,6 +136,7 @@ final class Unified extends AbstractText
         }
 
         $ret = $symbol . \implode("\n{$symbol}", $context) . "\n";
+        $ret = $this->cliColoredString($ret, $symbol);
 
         if ($noEolAtEof) {
             $ret .= self::GNU_OUTPUT_NO_EOL_AT_EOF . "\n";


### PR DESCRIPTION
With the new renderer option `cliColorization`

```php
$rendererOptions = [
    // this option is currently only for the Unified and the Context renderers.
    // RendererConstant::CLI_COLOR_AUTO = colorize the output if possible (default)
    // RendererConstant::CLI_COLOR_ENABLE = force to colorize the output
    // RendererConstant::CLI_COLOR_DISABLE = force not to colorize the output
    'cliColorization' => RendererConstant::CLI_COLOR_AUTO,
];
```

## Rendered Results (in CLI)

![2020-04-06_21-02-17](https://user-images.githubusercontent.com/6594915/78561434-4e9c4a80-784a-11ea-89ae-fc8a7ad43070.png)


## References

- Closes #28