### PR TITLE
fix: select the code only

### DIFF
--- a/example/diff-table.css
+++ b/example/diff-table.css
@@ -18,6 +18,7 @@
 .diff-wrapper.diff th {
   font-weight: 700;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
 }
 .diff-wrapper.diff td {

--- a/example/diff-table.css
+++ b/example/diff-table.css
@@ -17,6 +17,8 @@
 }
 .diff-wrapper.diff th {
   font-weight: 700;
+  cursor: default;
+  user-select: none;
 }
 .diff-wrapper.diff td {
   vertical-align: baseline;

--- a/example/diff-table.scss
+++ b/example/diff-table.scss
@@ -104,8 +104,6 @@ $diff-bg-color-none-block-alternative: mix($diff-bg-color, $diff-table-sidebar-c
       text-align: right;
       vertical-align: top;
       width: 4em;
-      cursor: default;
-      user-select: none;
 
       &.sign {
         background: $diff-bg-color;

--- a/example/diff-table.scss
+++ b/example/diff-table.scss
@@ -52,6 +52,9 @@ $diff-bg-color-none-block-alternative: mix($diff-bg-color, $diff-table-sidebar-c
 
   th {
     font-weight: 700;
+    cursor: default;
+    -webkit-user-select: none;
+    user-select: none;
   }
 
   td {
@@ -101,6 +104,8 @@ $diff-bg-color-none-block-alternative: mix($diff-bg-color, $diff-table-sidebar-c
       text-align: right;
       vertical-align: top;
       width: 4em;
+      cursor: default;
+      user-select: none;
 
       &.sign {
         background: $diff-bg-color;


### PR DESCRIPTION
With this PR the column headings and the line numbers etc are non selectable. This enables you to select only the relevant code with your mouse/keyboard.

### Before
![before](https://user-images.githubusercontent.com/1296369/191450278-2657500e-e30e-42ba-88cf-e5dae3b7f417.gif)

### After
![code](https://user-images.githubusercontent.com/1296369/191450134-754b3b85-7a40-48ad-b413-2034007afa50.gif)

### Limitation w side by side
Without adding some js it is not possible to limit the selection vertically

![limit](https://user-images.githubusercontent.com/1296369/191450512-d0e2c413-a3d1-4c5c-b3a6-cf95ec1a743c.gif)
