### PR TITLE
feat: new rendererOption: spaceToHtmlTag

### DIFF
--- a/example/demo_base.php
+++ b/example/demo_base.php
@@ -37,6 +37,10 @@ $rendererOptions = [
     'separateBlock' => true,
     // show the (table) header
     'showHeader' => true,
+    // convert spaces/tabs into HTML codes like `<span class="ch sp"> </span>`
+    // and the frontend is responsible for rendering them with CSS.
+    // when using this, "spacesToNbsp" should be false and "tabSize" is not respected.
+    'spaceToHtmlTag' => false,
     // the frontend HTML could use CSS "white-space: pre;" to visualize consecutive whitespaces
     // but if you want to visualize them in the backend with "&nbsp;", you can set this to true
     'spacesToNbsp' => false,

--- a/example/diff-table.css
+++ b/example/diff-table.css
@@ -73,6 +73,22 @@
 }
 .diff-wrapper.diff.diff-html {
   white-space: pre-wrap;
+  tab-size: var(--tab-size);
+}
+.diff-wrapper.diff.diff-html .ch {
+  line-height: 1em;
+  background-clip: border-box;
+  background-repeat: repeat-x;
+  background-position: left center;
+}
+.diff-wrapper.diff.diff-html .ch.sp {
+  background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba%2860, 60, 60, 50%25%29"/%3E%3C/svg%3E');
+  background-size: 1ch 1.25em;
+}
+.diff-wrapper.diff.diff-html .ch.tab {
+  background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba%2860, 60, 60, 50%25%29"/%3E%3C/svg%3E');
+  background-size: calc(var(--tab-size) * 1ch) 1.25em;
+  background-position: 2px center;
 }
 .diff-wrapper.diff.diff-html.diff-combined .change.change-rep .rep {
   white-space: normal;

--- a/example/diff-table.scss
+++ b/example/diff-table.scss
@@ -28,7 +28,13 @@ $diff-border-color: $diff-text-color !default;
 $diff-bg-color-none-block: mix($diff-bg-color, $diff-table-sidebar-color, 80%) !default;
 $diff-bg-color-none-block-alternative: mix($diff-bg-color, $diff-table-sidebar-color, 55%) !default;
 
+// symbol images
+$img-space: 'data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba%2860, 60, 60, 50%25%29"/%3E%3C/svg%3E' !default;
+$img-tab: 'data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba%2860, 60, 60, 50%25%29"/%3E%3C/svg%3E' !default;
+
 .diff-wrapper.diff {
+  --tab-size: 4;
+
   background: repeating-linear-gradient(
     -45deg,
     $diff-bg-color-none-block,
@@ -121,6 +127,24 @@ $diff-bg-color-none-block-alternative: mix($diff-bg-color, $diff-table-sidebar-c
 
   &.diff-html {
     white-space: pre-wrap;
+    tab-size: var(--tab-size);
+
+    .ch {
+      line-height: 1em;
+      background-clip: border-box;
+      background-repeat: repeat-x;
+      background-position: left center;
+
+      &.sp {
+        background-image: url($img-space);
+        background-size: 1ch 1.25em;
+      }
+      &.tab {
+        background-image: url($img-tab);
+        background-size: calc(var(--tab-size) * 1ch) 1.25em;
+        background-position: 2px center;
+      }
+    }
 
     &.diff-combined {
       .change.change-rep {

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -66,6 +66,10 @@ abstract class AbstractRenderer implements RendererInterface
         'separateBlock' => true,
         // show the (table) header
         'showHeader' => true,
+        // convert spaces/tabs into HTML codes like `<span class="ch sp"> </span>`
+        // and the frontend is responsible for rendering them with CSS.
+        // when using this, "spacesToNbsp" should be false and "tabSize" is not respected.
+        'spaceToHtmlTag' => false,
         // the frontend HTML could use CSS "white-space: pre;" to visualize consecutive whitespaces
         // but if you want to visualize them in the backend with "&nbsp;", you can set this to true
         'spacesToNbsp' => false,

--- a/src/Renderer/Html/AbstractHtml.php
+++ b/src/Renderer/Html/AbstractHtml.php
@@ -255,11 +255,18 @@ abstract class AbstractHtml extends AbstractRenderer
      */
     protected function formatStringFromLines(string $string): string
     {
-        $string = $this->expandTabs($string, $this->options['tabSize']);
+        if (!$this->options['spaceToHtmlTag']) {
+            $string = $this->expandTabs($string, $this->options['tabSize']);
+        }
+
         $string = $this->htmlSafe($string);
 
         if ($this->options['spacesToNbsp']) {
             $string = $this->htmlFixSpaces($string);
+        }
+
+        if ($this->options['spaceToHtmlTag']) {
+            $string = $this->htmlReplaceSpacesToHtmlTag($string);
         }
 
         return $string;
@@ -313,6 +320,21 @@ abstract class AbstractHtml extends AbstractRenderer
     protected function htmlFixSpaces(string $string): string
     {
         return str_replace(' ', '&nbsp;', $string);
+    }
+
+    /**
+     * Replace spaces/tabs with HTML tags, which may be styled in frontend with CSS.
+     *
+     * @param string $string the string of spaces
+     *
+     * @return string the HTML representation of the string
+     */
+    protected function htmlReplaceSpacesToHtmlTag(string $string): string
+    {
+        return strtr($string, [
+            ' ' => '<span class="ch sp"> </span>',
+            "\t" => "<span class=\"ch tab\">\t</span>",
+        ]);
     }
 
     /**


### PR DESCRIPTION
convert spaces/tabs into HTML codes like `<span class="ch sp"> </span>` and the frontend is responsible for rendering them with CSS. when using this, "spacesToNbsp" should be false and "tabSize" is not respected.

---

Tested with 

```php
    // convert spaces/tabs into HTML codes like `<span class="ch sp"> </span>`
    // and the frontend is responsible for rendering them with CSS.
    // when using this, "spacesToNbsp" should be false and "tabSize" is not respected.
    'spaceToHtmlTag' => true,
    // the frontend HTML could use CSS "white-space: pre;" to visualize consecutive whitespaces
    // but if you want to visualize them in the backend with "&nbsp;", you can set this to true
    'spacesToNbsp' => false,
```

![image](https://user-images.githubusercontent.com/6594915/191523194-5d6d6137-3875-441c-8b5e-2eed257296fb.png)

---

Resolves https://github.com/jfcherng/php-diff/issues/58