### PR TITLE
Update config for HTML renderer to allow override for header text

### DIFF
--- a/example/demo_base.php
+++ b/example/demo_base.php
@@ -37,6 +37,14 @@ $rendererOptions = [
     'separateBlock' => true,
     // show the (table) header
     'showHeader' => true,
+    // override header info
+    // old/new_version for side by side, difference for combined views, all three for inline
+    // if set to null or not existing will fallback to default values
+    'overrideHeader' => [
+        'old_version' => null,
+        'new_version' => null,
+        'difference' => null,
+    ],
     // convert spaces/tabs into HTML codes like `<span class="ch sp"> </span>`
     // and the frontend is responsible for rendering them with CSS.
     // when using this, "spacesToNbsp" should be false and "tabSize" is not respected.

--- a/example/demo_web.php
+++ b/example/demo_web.php
@@ -52,6 +52,26 @@ use Jfcherng\Diff\Factory\RendererFactory;
 
     ?>
 
+    <h1>None-level Diff / Override header</h1>
+    <?php
+
+    // demo the no-inline-detail diff
+    $inlineResult = DiffHelper::calculate(
+        $oldString,
+        $newString,
+        'Inline',
+        $diffOptions,
+        ['overrideHeader' => [
+            'old_version' => 'Orig',
+            'new_version' => 'Curr',
+            'differences' => 'Changes',
+        ]] + ['detailLevel' => 'none'] + $rendererOptions,
+    );
+
+    echo $inlineResult;
+
+    ?>
+
     <h1>Line-level Diff (Default)</h1>
     <?php
 
@@ -110,6 +130,44 @@ use Jfcherng\Diff\Factory\RendererFactory;
         'SideBySide',
         $diffOptions,
         $rendererOptions,
+    );
+
+    echo $sideBySideResult;
+
+    ?>
+
+    <h1>Side by Side Diff / Override header</h1>
+    <?php
+
+    // generate a side by side diff
+    $sideBySideResult = DiffHelper::calculateFiles(
+        $oldFile,
+        $newFile,
+        'SideBySide',
+        $diffOptions,
+        ['overrideHeader' => [
+            'old_version' => 'Original',
+            'new_version' => 'Current',
+        ]] + $rendererOptions,
+    );
+
+    echo $sideBySideResult;
+
+    ?>
+
+<h1>Side by Side Diff / Override header with HTML</h1>
+    <?php
+
+    // generate a side by side diff
+    $sideBySideResult = DiffHelper::calculateFiles(
+        $oldFile,
+        $newFile,
+        'SideBySide',
+        $diffOptions,
+        ['overrideHeader' => [
+            'old_version' => '<span style="color: red;">Original</span>',
+            'new_version' => '<span style="color: blue;">Current</span>',
+        ]] + $rendererOptions,
     );
 
     echo $sideBySideResult;

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -66,6 +66,14 @@ abstract class AbstractRenderer implements RendererInterface
         'separateBlock' => true,
         // show the (table) header
         'showHeader' => true,
+        // override header info
+        // old/new for side by side, difference for combined views
+        // if set to null or not existing will fallback to default values
+        'overrideHeader' => [
+            'old_version' => null,
+            'new_version' => null,
+            'difference' => null,
+        ],
         // convert spaces/tabs into HTML codes like `<span class="ch sp"> </span>`
         // and the frontend is responsible for rendering them with CSS.
         // when using this, "spacesToNbsp" should be false and "tabSize" is not respected.

--- a/src/Renderer/Html/Combined.php
+++ b/src/Renderer/Html/Combined.php
@@ -60,10 +60,16 @@ final class Combined extends AbstractHtml
             return '';
         }
 
+        $differences = $this->_('differences');
+        if (isset($this->options['overrideHeader']['differences'])) {
+            $differences =
+                $this->options['overrideHeader']['differences'];
+        }
+
         return
             '<thead>' .
                 '<tr>' .
-                    '<th>' . $this->_('differences') . '</th>' .
+                    '<th>' . $differences . '</th>' .
                 '</tr>' .
             '</thead>';
     }

--- a/src/Renderer/Html/Inline.php
+++ b/src/Renderer/Html/Inline.php
@@ -51,19 +51,34 @@ final class Inline extends AbstractHtml
 
         $colspan = $this->options['lineNumbers'] ? '' : ' colspan="2"';
 
+        $old_version = '';
+        $new_version = '';
+        $differences = '';
+        foreach (
+            [
+                'old_version', 'new_version', 'differences'
+            ] as $header_string
+        ) {
+            $$header_string = $this->_($header_string);
+            if (isset($this->options['overrideHeader'][$header_string])) {
+                $$header_string =
+                    $this->options['overrideHeader'][$header_string];
+            }
+        }
+
         return
             '<thead>' .
                 '<tr>' .
                     (
                         $this->options['lineNumbers']
                         ?
-                            '<th>' . $this->_('old_version') . '</th>' .
-                            '<th>' . $this->_('new_version') . '</th>' .
+                            '<th>' . $old_version . '</th>' .
+                            '<th>' . $new_version . '</th>' .
                             '<th></th>' // diff symbol column
                         :
                             ''
                     ) .
-                    '<th' . $colspan . '>' . $this->_('differences') . '</th>' .
+                    '<th' . $colspan . '>' . $differences . '</th>' .
                 '</tr>' .
             '</thead>';
     }

--- a/src/Renderer/Html/SideBySide.php
+++ b/src/Renderer/Html/SideBySide.php
@@ -49,13 +49,23 @@ final class SideBySide extends AbstractHtml
             return '';
         }
 
+        $old_version = '';
+        $new_version = '';
+        foreach (['old_version', 'new_version'] as $header_string) {
+            $$header_string = $this->_($header_string);
+            if (isset($this->options['overrideHeader'][$header_string])) {
+                $$header_string =
+                    $this->options['overrideHeader'][$header_string];
+            }
+        }
+
         $colspan = $this->options['lineNumbers'] ? ' colspan="2"' : '';
 
         return
             '<thead>' .
                 '<tr>' .
-                    '<th' . $colspan . '>' . $this->_('old_version') . '</th>' .
-                    '<th' . $colspan . '>' . $this->_('new_version') . '</th>' .
+                    '<th' . $colspan . '>' . $old_version . '</th>' .
+                    '<th' . $colspan . '>' . $new_version . '</th>' .
                 '</tr>' .
             '</thead>';
     }


### PR DESCRIPTION
new config setting:

```php
overrideHeader' => [
    'old_version' => null,
    'new_version' => null,
    'difference' => null,
],
```

Name matches the names used in the translation file.

if `null` or not set in array then the original value will be used.

HTML is allowed (user needs to sanitize html)

Examples updated