### PR TITLE
feat: add new differ option: fullContextIfIdentical

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ $differOptions = [
     'ignoreWhitespace' => false,
     // if the input sequence is too long, it will just gives up (especially for char-level diff)
     'lengthLimit' => 2000,
+    // if truthy, when inputs are identical, the whole inputs will be rendered in the output
+    'fullContextIfIdentical' => false,
 ];
 
 // the renderer class options

--- a/example/demo_base.php
+++ b/example/demo_base.php
@@ -26,6 +26,8 @@ $diffOptions = [
     'ignoreWhitespace' => false,
     // if the input sequence is too long, it will just gives up (especially for char-level diff)
     'lengthLimit' => 2000,
+    // if truthy, when inputs are identical, the whole inputs will be rendered in the output
+    'fullContextIfIdentical' => false,
 ];
 
 // options for renderer class

--- a/src/Differ.php
+++ b/src/Differ.php
@@ -113,6 +113,8 @@ final class Differ
         'ignoreWhitespace' => false,
         // if the input sequence is too long, it will just gives up (especially for char-level diff)
         'lengthLimit' => 2000,
+        // if truthy, when inputs are identical, the whole inputs will be rendered in the output
+        'fullContextIfIdentical' => false,
     ];
 
     /**
@@ -310,10 +312,21 @@ final class Differ
             return $this->groupedOpcodes;
         }
 
-        $this->getGroupedOpcodesPre($this->old, $this->new);
+        $old = $this->old;
+        $new = $this->new;
+
+        if ($this->oldNewComparison === 0 && $this->options['fullContextIfIdentical']) {
+            return [
+                [
+                    [SequenceMatcher::OP_EQ, 0, \count($old), 0, \count($new)],
+                ],
+            ];
+        }
+
+        $this->getGroupedOpcodesPre($old, $new);
 
         $opcodes = $this->sequenceMatcher
-            ->setSequences($this->old, $this->new)
+            ->setSequences($old, $new)
             ->getGroupedOpcodes($this->options['context'])
         ;
 
@@ -335,10 +348,21 @@ final class Differ
             return $this->groupedOpcodesGnu;
         }
 
-        $this->getGroupedOpcodesGnuPre($this->old, $this->new);
+        $old = $this->old;
+        $new = $this->new;
+
+        if ($this->oldNewComparison === 0 && $this->options['fullContextIfIdentical']) {
+            return [
+                [
+                    [SequenceMatcher::OP_EQ, 0, \count($old), 0, \count($new)],
+                ],
+            ];
+        }
+
+        $this->getGroupedOpcodesGnuPre($old, $new);
 
         $opcodes = $this->sequenceMatcher
-            ->setSequences($this->old, $this->new)
+            ->setSequences($old, $new)
             ->getGroupedOpcodes($this->options['context'])
         ;
 

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -181,7 +181,7 @@ abstract class AbstractRenderer implements RendererInterface
         $this->changesAreRaw = true;
 
         // the "no difference" situation may happen frequently
-        return $differ->getOldNewComparison() === 0
+        return $differ->getOldNewComparison() === 0 && !$differ->options['fullContextIfIdentical']
             ? $this->getResultForIdenticals()
             : $this->renderWorker($differ);
     }

--- a/tests/Renderer/RendererTest.php
+++ b/tests/Renderer/RendererTest.php
@@ -52,6 +52,36 @@ final class RendererTest extends TestCase
      *
      * @covers \Jfcherng\Diff\Renderer\AbstractRenderer::setOptions
      */
+    public function testSetOptionsWithFullContextIfIdentical(): void
+    {
+        $diffResult = DiffHelper::calculate(
+            "the 1st line\nthe 2nd line\nthe 3rd line",
+            "the 1st line\nthe 2nd line\nthe 3rd line",
+            'Unified',
+            ['fullContextIfIdentical' => true],
+            [],
+        );
+
+        self::assertSame(
+            <<<'DIFF'
+@@ -1,3 +1,3 @@
+ the 1st line
+ the 2nd line
+ the 3rd line
+\ No newline at end of file
+
+DIFF
+            ,
+            $diffResult,
+            'Differ options: "fullContextIfIdentical" should work.',
+        );
+    }
+
+    /**
+     * Test the AbstractRenderer::setOptions with result for identicals.
+     *
+     * @covers \Jfcherng\Diff\Renderer\AbstractRenderer::setOptions
+     */
     public function testSetOptionsWithResultForIdenticals(): void
     {
         $testMarker = '_TEST_MARKER_';


### PR DESCRIPTION
When it's truthy and there is no difference, the diff output would be the whole file marked as "equal". Otherwise, it just returns null.

resolves #78