### PR TITLE
Update PHP versions in workflow configuration

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php-versions: ["7.4", "8.0", "8.1", "8.2"]
+        php-versions: ["7.4", "8.5"]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
I wanted to use this, but it has a few deprecations and warnings.
best to check for 8.5 compability. Which also includes all below, so basically you always only need min/max testing matrix.