### PR TITLE
fix: numeric string arrays incorrectly treated as identical

### DIFF
--- a/src/Differ.php
+++ b/src/Differ.php
@@ -483,7 +483,7 @@ final class Differ
 
             $this->oldNoEolAtEofIdx = $this->getOld(-1) === [''] ? -1 : \count($this->old);
             $this->newNoEolAtEofIdx = $this->getNew(-1) === [''] ? -1 : \count($this->new);
-            $this->oldNewComparison = $this->old <=> $this->new;
+            $this->oldNewComparison = $this->old === $this->new ? 0 : ($this->old <=> $this->new ?: 1);
 
             $this->sequenceMatcher->setOptions($this->options->toSequenceMatcherOptions());
         }

--- a/tests/DifferTest.php
+++ b/tests/DifferTest.php
@@ -19,6 +19,19 @@ use PHPUnit\Framework\TestCase;
 final class DifferTest extends TestCase
 {
     /**
+     * Test that numeric strings that are equal numerically but not identical
+     * (e.g. "00" vs "0") are correctly detected as different.
+     *
+     * @covers \Jfcherng\Diff\Differ::getOldNewComparison
+     */
+    public function testNumericStringComparisonIsStrict(): void
+    {
+        $differ = new Differ(['00'], ['0']);
+
+        self::assertNotSame(0, $differ->getOldNewComparison());
+    }
+
+    /**
      * Test the Differ::getGroupedOpcodes.
      *
      * @covers \Jfcherng\Diff\Differ::getGroupedOpcodes


### PR DESCRIPTION
PHP 8's `<=>` compares numeric string arrays numerically, so `['00'] <=> ['0']` returns 0. The renderer sees this as "identical" and returns empty output.

Fix: check `===` first for equality, only use `<=>` for ordering. Force non-zero when arrays differ but spaceship says otherwise.

Reproducer:
```php
DiffHelper::calculate('00', '0', 'SideBySide'); // returns '' instead of a diff
DiffHelper::calculate('1', '01', 'SideBySide'); // same issue
```

Fixes #94